### PR TITLE
feat(auth): mount auth router + regression test

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,3 @@
+from .index import app
+
+__all__ = ["app"]

--- a/api/index.py
+++ b/api/index.py
@@ -1,1 +1,11 @@
 from src.index import app
+
+try:
+    from api.auth import router as auth_router
+except ModuleNotFoundError:
+    from src.auth import router as auth_router
+
+if not any(getattr(route, 'path', '').startswith('/auth') for route in app.router.routes):
+    app.include_router(auth_router, prefix="/auth", tags=["auth"])
+
+__all__ = ["app"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 fastapi==0.95.1
 requests==2.30.0
 uvicorn==0.22.0
+python-dotenv
+httpx
+pytest

--- a/src/index.py
+++ b/src/index.py
@@ -7,7 +7,6 @@ from fastapi.staticfiles import StaticFiles
 from src.dtos.api import TrackTitles, TrackURIs
 from src.utils import get_spotify_client
 from src.services.spotify import SpotifyClient
-from src.auth import router as auth_router
 
 app = FastAPI()
 
@@ -24,7 +23,6 @@ app.add_middleware(
 )
 
 app.mount("/static", StaticFiles(directory="static"), name="static")
-app.include_router(auth_router)
 
 # Welcome endpoint 
 

--- a/tests/test_auth_route.py
+++ b/tests/test_auth_route.py
@@ -1,0 +1,16 @@
+import sys, types
+
+try:
+    import httpx  # type: ignore
+except ModuleNotFoundError:  # fallback stub for offline envs
+    httpx = types.ModuleType('httpx')
+    sys.modules['httpx'] = httpx
+import pytest
+from fastapi.testclient import TestClient
+from api.index import app
+
+client = TestClient(app)
+
+def test_login_route_redirect():
+    response = client.get('/auth/login', allow_redirects=False)
+    assert response.status_code in (302, 307)


### PR DESCRIPTION
## Summary
- expose FastAPI app from `api` and mount auth router with `/auth`
- stub out optional `httpx` dependency and add regression test for `/auth/login`
- ensure `app` is exported via `api/__init__.py`
- add testing dependencies to `requirements.txt`

## Testing
- `pytest -q` *(fails: module 'httpx' has no attribute 'BaseTransport')*

------
https://chatgpt.com/codex/tasks/task_e_68603ef35ea483279083dcf71100aa05