### PR TITLE
Fix tests with httpx 0.24+ compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ fastapi==0.95.1
 requests==2.30.0
 uvicorn==0.22.0
 python-dotenv
-httpx
-pytest
+httpx>=0.24
+pytest>=7

--- a/tests/test_auth_route.py
+++ b/tests/test_auth_route.py
@@ -1,4 +1,5 @@
 import sys, types
+import os
 
 try:
     import httpx  # type: ignore
@@ -6,6 +7,19 @@ except ModuleNotFoundError:  # fallback stub for offline envs
     httpx = types.ModuleType('httpx')
     sys.modules['httpx'] = httpx
 import pytest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Patch httpx.Client to support the deprecated `app` parameter used by Starlette
+if hasattr(httpx, "ASGITransport"):
+    _orig_init = httpx.Client.__init__
+
+    def _patched_init(self, *args, app=None, **kwargs):
+        if app is not None:
+            kwargs.setdefault("transport", httpx.ASGITransport(app=app))
+        _orig_init(self, *args, **kwargs)
+
+    httpx.Client.__init__ = _patched_init  # type: ignore
+
 from fastapi.testclient import TestClient
 from api.index import app
 


### PR DESCRIPTION
## Summary
- bump `httpx` to `>=0.24` and `pytest` to `>=7`
- patch `httpx.Client` in tests to add deprecated `app` argument support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860410efa08832797f18da0ad6ada6f