### PR TITLE
Fix OAuth redirect handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ To integrate ChatGPT with Spotify API via OAuth, you have to set up a Spotify ap
 
 4. Accept the terms and conditions and click "Create".
 
+### 🔑 OAuth setup
+
+The **same** URL must appear both in Railway → Variables → `REDIRECT_URI`
+and in the Spotify Dashboard → Redirect URIs.
+
 ### Setup the plugin
 
 To install the required packages for this plugin, run the following command:


### PR DESCRIPTION
## Summary
- enforce REDIRECT_URI via env var and encode scopes with `%20`
- document shared REDIRECT_URI between Railway and Spotify console
- test login redirect for correct parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68604711cf2483279e1caec4e306ee36