### PR TITLE
Restore top_tracks endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,13 @@ Once the plugin is installed, you'd like to try the following prompts:
 
 > **Prompt 2**: "There's this one artist named 'John Smith' who is my absolute favorite, and I can't get enough of their music. Could you curate a playlist based on 'John Smith's' style and genre? I'm looking to explore more songs that resonate with their sound."
 
+
+## API
+
+### `GET /top_tracks`
+
+Returns the top 5 tracks for the authenticated user.
+
+```bash
+curl https://spotigen.vercel.app/top_tracks -H "Authorization: Bearer <ACCESS_TOKEN>"
+```

--- a/api/index.py
+++ b/api/index.py
@@ -1,5 +1,7 @@
 from src.index import app
 
+from src.tracks import router as tracks_router
+
 try:
     from api.auth import router as auth_router
 except ModuleNotFoundError:
@@ -7,5 +9,7 @@ except ModuleNotFoundError:
 
 if not any(getattr(route, 'path', '').startswith('/auth') for route in app.router.routes):
     app.include_router(auth_router, prefix="/auth", tags=["auth"])
+
+app.include_router(tracks_router)
 
 __all__ = ["app"]

--- a/src/tracks.py
+++ b/src/tracks.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, HTTPException
+from .auth import valid_access_token
+import requests
+
+router = APIRouter()
+
+@router.get("/top_tracks")
+def top_tracks():
+    token = valid_access_token()
+    if not token:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    r = requests.get(
+        "https://api.spotify.com/v1/me/top/tracks?limit=5",
+        headers={"Authorization": f"Bearer {token}"}
+    )
+    return r.json()

--- a/tests/test_top_tracks.py
+++ b/tests/test_top_tracks.py
@@ -1,0 +1,28 @@
+import os, sys, types, importlib
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+try:
+    import httpx  # type: ignore
+except ModuleNotFoundError:
+    httpx = types.ModuleType("httpx")
+    sys.modules["httpx"] = httpx
+if hasattr(httpx, "ASGITransport"):
+    _orig_init = httpx.Client.__init__
+    def _patched_init(self, *args, app=None, **kwargs):
+        if app is not None:
+            kwargs.setdefault("transport", httpx.ASGITransport(app=app))
+        _orig_init(self, *args, **kwargs)
+    httpx.Client.__init__ = _patched_init  # type: ignore
+from fastapi.testclient import TestClient
+
+
+def test_top_tracks_no_token(monkeypatch):
+    monkeypatch.setenv("CLIENT_ID", "dummy")
+    monkeypatch.setenv("REDIRECT_URI", "https://example.com/callback")
+    import src.index, src.tracks, api.index
+    importlib.reload(src.index)
+    importlib.reload(src.tracks)
+    monkeypatch.setattr(src.tracks, "valid_access_token", lambda: None)
+    importlib.reload(api.index)
+    client = TestClient(api.index.app)
+    r = client.get("/top_tracks")
+    assert r.status_code == 401


### PR DESCRIPTION
## Summary
- add `src/tracks.py` containing `/top_tracks` route
- register the new router in `api/index.py`
- provide a test for the unauthenticated call
- document the endpoint in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686081067d20832792307d55d5ebdb03