### PR TITLE
Update production config and OpenAPI

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -6,7 +6,7 @@
   "description_for_human": "Spotigen is an AI DJ crafting playlists to match your mood or day, and enhancing your content with suitable music.",
   "auth": {
     "type": "oauth",
-    "client_url": "https://accounts.spotify.com/authorize",
+    "client_url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/auth/login",
     "scope": "playlist-modify-public",
     "authorization_url": "https://accounts.spotify.com/api/token",
     "authorization_content_type": "application/x-www-form-urlencoded",
@@ -16,7 +16,7 @@
   },
   "api": {
     "type": "openapi",
-    "url": "https://spotigen.vercel.app/static/openapi.yaml",
+    "url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/openapi.yaml",
     "is_user_authenticated": true
   },
   "logo_url": "https://spotigen.vercel.app/static/logo.png",

--- a/api/index.py
+++ b/api/index.py
@@ -1,4 +1,5 @@
 from src.index import app
+from fastapi.middleware.cors import CORSMiddleware
 
 from src.tracks import router as tracks_router
 
@@ -11,5 +12,14 @@ if not any(getattr(route, 'path', '').startswith('/auth') for route in app.route
     app.include_router(auth_router, prefix="/auth", tags=["auth"])
 
 app.include_router(tracks_router)
+
+# Ensure CORS is enabled when the app is imported directly from this module.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 __all__ = ["app"]

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,89 +1,14 @@
 openapi: 3.1.0
 info:
-  title: Spotigen
-  description: |
-    Plugin “Spotigen” – crée et gère des playlists Spotify selon l’humeur de l’utilisateur.
-  version: v1
-
+  title: Spotigen API
+  version: "1.0"
 servers:
   - url: https://spotigen-chat-gpt-plugin-production.up.railway.app
-
 paths:
-  /:
-    get:
-      summary: Root
-      operationId: root__get
-      responses:
-        "200":
-          description: Successful Response
-
-  /login:
-    get:
-      summary: OAuth Login
-      operationId: login_login_get
-      responses:
-        "307":
-          description: Redirect to Spotify OAuth
-
-  /callback:
-    get:
-      summary: OAuth Callback
-      operationId: callback_callback_get
-      parameters:
-        - name: code
-          in: query
-          required: false
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Auth success
-
-  /refresh:
-    get:
-      summary: Refresh Access Token
-      operationId: refresh_refresh_get
-      responses:
-        "200":
-          description: New access token
-
   /top_tracks:
     get:
       summary: Top Tracks
-      operationId: top_tracks_top_tracks_get
+      operationId: top_tracks
       responses:
         "200":
           description: Successful Response
-
-  /create_playlist:
-    post:
-      summary: Create Playlist
-      operationId: create_playlist_create_playlist_post
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PlaylistRequest'
-      responses:
-        "200":
-          description: Successful Response
-
-components:
-  schemas:
-    PlaylistRequest:
-      type: object
-      properties:
-        name:
-          type: string
-        description:
-          type: string
-          default: ""
-        public:
-          type: boolean
-          default: true
-        track_uris:
-          type: array
-          items:
-            type: string
-      required: [name]


### PR DESCRIPTION
## Summary
- point manifest to production server
- simplify OpenAPI spec for `/top_tracks`
- enable CORS middleware

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68609d8989cc83278cd1117485a6688f