### PR TITLE
Serve manifest from correct location

### DIFF
--- a/src/index.py
+++ b/src/index.py
@@ -40,12 +40,9 @@ async def plugin_logo():
 
 @app.get("/.well-known/ai-plugin.json")
 async def plugin_manifest():
-    if _ENV == 'production':
-        print(_ENV, "production")
-        return FileResponse("static/ai-plugin.json")
-    else:
-        print(_ENV, "development")
-        return FileResponse("static/ai-plugin-dev.json")
+    """Return the plugin manifest used by ChatGPT."""
+    print("ai-plugin.json", _ENV)
+    return FileResponse(".well-known/ai-plugin.json")
 
 @app.get("/openapi.yaml")
 async def openapi_spec():


### PR DESCRIPTION
## Summary
- return `.well-known/ai-plugin.json` in plugin endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860a4c351488327964be3c9d3690f4d