### PR TITLE
Fix server URL in OpenAPI spec

### DIFF
--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: Plugin to craft personalized music playlists based on a user's mood, daily experiences, or preferences. By interpreting descriptions of the user's day or emotional state, the plugin generates playlists that mirror these feelings. Spotigen can also enhance user-generated content such as social media stories or statuses by suggesting mood-congruent music. Additionally, it can construct playlists drawing inspiration from the user's favorite lists. Use it whenever a user desires to channel their emotions into music, enhance their online content with appropriate soundtracks, or explore new melodies resonating with their favorites.
   version: 'v1'
 servers:
-  - url: https://spotigen.vercel.app
+  - url: https://spotigen-chat-gpt-plugin-production.up.railway.app
 paths:
   "/":
     get:


### PR DESCRIPTION
## Summary
- match the server URL in `openapi.yaml` to the production Railway domain

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686151e3bdf8832795c5e3641fb21f6f