### PR TITLE
Add httpx requirement and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,12 @@ Returns the top 5 tracks for the authenticated user.
 ```bash
 curl https://spotigen.vercel.app/top_tracks -H "Authorization: Bearer <ACCESS_TOKEN>"
 ```
+
+## Testing
+
+Install the required packages before running the test suite:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ fastapi==0.95.1
 requests==2.30.0
 uvicorn==0.22.0
 python-dotenv
-httpx>=0.24
+httpx==0.28.1
 pytest>=7


### PR DESCRIPTION
## Summary
- pin httpx in `requirements.txt`
- add note on installing dependencies before running tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861591cbec48327aedbc5321b1353dc