### PR TITLE
Add manifest URL test

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -16,7 +16,7 @@
   },
   "api": {
     "type": "openapi",
-    "url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/openapi.yaml",
+    "url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/openapi.json",
     "is_user_authenticated": true
   },
   "logo_url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/static/logo.png",

--- a/src/index.py
+++ b/src/index.py
@@ -8,7 +8,7 @@ from src.dtos.api import TrackTitles, TrackURIs
 from src.utils import get_spotify_client
 from src.services.spotify import SpotifyClient
 
-app = FastAPI()
+app = FastAPI(servers=[{"url": "https://spotigen-chat-gpt-plugin-production.up.railway.app"}])
 
 _ENV = os.environ.get('VERCEL_ENV')
 

--- a/static/ai-plugin-dev.json
+++ b/static/ai-plugin-dev.json
@@ -16,7 +16,7 @@
   },
   "api": {
     "type": "openapi",
-    "url": "https://f155-38-25-25-120.ngrok-free.app/static/openapi.yaml",
+    "url": "https://f155-38-25-25-120.ngrok-free.app/static/openapi.json",
     "is_user_authenticated": false
   },
   "logo_url": "https://f155-38-25-25-120.ngrok-free.app/static/logo.png",	

--- a/static/ai-plugin.json
+++ b/static/ai-plugin.json
@@ -16,7 +16,7 @@
   },
   "api": {
     "type": "openapi",
-    "url": "https://spotigen.vercel.app/static/openapi.yaml",
+    "url": "https://spotigen.vercel.app/static/openapi.json",
     "is_user_authenticated": true
   },
   "logo_url": "https://spotigen.vercel.app/static/logo.png",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,41 @@
+import os, sys, types, importlib, urllib.parse
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+try:
+    import httpx  # type: ignore
+except ModuleNotFoundError:
+    httpx = types.ModuleType("httpx")
+    sys.modules["httpx"] = httpx
+if hasattr(httpx, "ASGITransport"):
+    _orig_init = httpx.Client.__init__
+    def _patched_init(self, *args, app=None, **kwargs):
+        if app is not None:
+            kwargs.setdefault("transport", httpx.ASGITransport(app=app))
+        _orig_init(self, *args, **kwargs)
+    httpx.Client.__init__ = _patched_init  # type: ignore
+from fastapi.testclient import TestClient
+import json
+import re
+
+
+def test_manifest(monkeypatch):
+    monkeypatch.setenv("CLIENT_ID", "dummy")
+    monkeypatch.setenv("REDIRECT_URI", "https://example.com/callback")
+    import api.index
+    client = TestClient(api.index.app)
+
+    resp = client.get("/.well-known/ai-plugin.json")
+    assert resp.status_code == 200
+    manifest = resp.json()
+
+    openapi_url = manifest["api"]["url"]
+    assert openapi_url.endswith("/openapi.json")
+    path = urllib.parse.urlparse(openapi_url).path
+    spec_resp = client.get(path)
+    assert spec_resp.status_code == 200
+    if path.endswith(".json"):
+        spec = spec_resp.json()
+        servers = [s.get("url", "") for s in spec.get("servers", [])]
+        assert any(url.startswith("https://spotigen-chat-gpt-plugin-production.") for url in servers)
+    else:
+        # YAML or plain text fallback
+        assert re.search(r"https://spotigen-chat-gpt-plugin-production\.", spec_resp.text)


### PR DESCRIPTION
## Summary
- add manifest test for openapi.json URL and server prefix
- update manifest JSONs to reference `/openapi.json`
- include server URL in FastAPI config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861591969e48327bd72fec5d0224f18