### PR TITLE
Serve json OpenAPI spec

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -16,7 +16,7 @@
   },
   "api": {
     "type": "openapi",
-    "url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/openapi.yaml",
+    "url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/openapi.json",
     "is_user_authenticated": true
   },
   "logo_url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/static/logo.png",

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,443 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Spotigen",
+    "description": "Plugin to craft personalized music playlists based on a user's mood, daily experiences, or preferences. By interpreting descriptions of the user's day or emotional state, the plugin generates playlists that mirror these feelings. Spotigen can also enhance user-generated content such as social media stories or statuses by suggesting mood-congruent music. Additionally, it can construct playlists drawing inspiration from the user's favorite lists. Use it whenever a user desires to channel their emotions into music, enhance their online content with appropriate soundtracks, or explore new melodies resonating with their favorites.",
+    "version": "v1"
+  },
+  "servers": [
+    {
+      "url": "https://spotigen-chat-gpt-plugin-production.up.railway.app"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "Root",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/logo.png": {
+      "get": {
+        "summary": "Plugin Logo",
+        "operationId": "plugin_logo_logo_png_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/.well-known/ai-plugin.json": {
+      "get": {
+        "summary": "Plugin Manifest",
+        "operationId": "plugin_manifest__well_known_ai_plugin_json_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi.yaml": {
+      "get": {
+        "summary": "Openapi Spec",
+        "operationId": "openapi_spec_openapi_yaml_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/login": {
+      "get": {
+        "summary": "OAuth Login",
+        "operationId": "login_login_get",
+        "responses": {
+          "307": {
+            "description": "Redirect to Spotify OAuth"
+          }
+        }
+      }
+    },
+    "/callback": {
+      "get": {
+        "summary": "OAuth Callback",
+        "operationId": "callback_callback_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Auth success"
+          }
+        }
+      }
+    },
+    "/refresh": {
+      "get": {
+        "summary": "Refresh Access Token",
+        "operationId": "refresh_refresh_get",
+        "responses": {
+          "200": {
+            "description": "New access token"
+          }
+        }
+      }
+    },
+    "/playlist": {
+      "get": {
+        "summary": "Get Playlist",
+        "operationId": "get_playlist_playlist_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            },
+            "name": "name",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create Playlist",
+        "operationId": "create_playlist_playlist_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            },
+            "name": "name",
+            "in": "query"
+          },
+          {
+            "required": true,
+            "schema": {
+              "title": "Public",
+              "type": "boolean"
+            },
+            "name": "public",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/playlist/{playlist_id}/tracks": {
+      "get": {
+        "summary": "Get Playlist Tracks",
+        "operationId": "get_playlist_tracks_playlist__playlist_id__tracks_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Playlist Id",
+              "type": "string"
+            },
+            "name": "playlist_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "Add Tracks To Playlist",
+        "operationId": "add_tracks_to_playlist_playlist__playlist_id__tracks_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Playlist Id",
+              "type": "string"
+            },
+            "name": "playlist_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackTitles"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      },
+      "delete": {
+        "summary": "Remove Tracks From Playlist",
+        "operationId": "remove_tracks_from_playlist_playlist__playlist_id__tracks_delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Playlist Id",
+              "type": "string"
+            },
+            "name": "playlist_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackURIs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "title": "HTTPValidationError",
+        "type": "object",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          }
+        }
+      },
+      "TrackTitles": {
+        "title": "TrackTitles",
+        "required": [
+          "titles"
+        ],
+        "type": "object",
+        "properties": {
+          "titles": {
+            "title": "Titles",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "TrackURIs": {
+        "title": "TrackURIs",
+        "required": [
+          "track_uris"
+        ],
+        "type": "object",
+        "properties": {
+          "track_uris": {
+            "title": "Track Uris",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ValidationError": {
+        "title": "ValidationError",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "loc": {
+            "title": "Location",
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            }
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "HTTPBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  }
+}

--- a/src/index.py
+++ b/src/index.py
@@ -44,10 +44,11 @@ async def plugin_manifest():
     print("ai-plugin.json", _ENV)
     return FileResponse(".well-known/ai-plugin.json")
 
-@app.get("/openapi.yaml")
-async def openapi_spec():
-    print("openapi.yaml", _ENV)
-    return FileResponse("static/openapi.yaml")
+@app.get("/openapi.json")
+async def openapi_spec_json():
+    """Return the OpenAPI specification in JSON format."""
+    print("openapi.json", _ENV)
+    return FileResponse("openapi.json")
 
 
 # ChatGPT plugin endpoints for Spotify


### PR DESCRIPTION
## Summary
- add `openapi.json` generated from `static/openapi.yaml`
- serve `/openapi.json` and remove old YAML route
- update plugin manifest to point at json spec

## Testing
- `pytest -q`
- `pip install PyYAML` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68615917ae0083279f1982547e401839