### PR TITLE
Fix OpenAPI route for ChatGPT plugin

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -16,7 +16,7 @@
   },
   "api": {
     "type": "openapi",
-    "url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/openapi.json?v=5",
+    "url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/spec.json?v=6",
     "is_user_authenticated": true
   },
   "logo_url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/static/logo.png",

--- a/src/index.py
+++ b/src/index.py
@@ -18,11 +18,9 @@ from src.utils import get_spotify_client
 ROOT_DIR = Path(__file__).resolve().parent.parent
 
 app = FastAPI(
-    servers=[
-        {
-            "url": "https://spotigen-chat-gpt-plugin-production.up.railway.app"
-        }
-    ]
+    servers=[{"url": "https://spotigen-chat-gpt-plugin-production.up.railway.app"}],
+    openapi_url=None,
+    docs_url=None,
 )
 
 _ENV = os.getenv("VERCEL_ENV", "development")  # Railway → "production" / local → dev
@@ -57,9 +55,9 @@ async def plugin_logo() -> FileResponse:
     return FileResponse("static/logo.png", media_type="image/png")
 
 
-@app.get("/openapi.json", include_in_schema=False)
-async def openapi_spec_json() -> FileResponse:
-    """Serve the OpenAPI specification in JSON so ChatGPT can parse it."""
+@app.get("/spec.json", include_in_schema=False)
+async def custom_openapi() -> FileResponse:
+    """Serve the OpenAPI specification so ChatGPT can parse it."""
     return FileResponse(ROOT_DIR / "openapi.json", media_type="application/json")
 
 

--- a/tests/test_content_type.py
+++ b/tests/test_content_type.py
@@ -22,5 +22,5 @@ def test_openapi_content_type(monkeypatch):
     monkeypatch.setenv("REDIRECT_URI", "https://example.com/callback")
     importlib.reload(src.index)
     client = TestClient(src.index.app)
-    r = client.get("/openapi.json?v=5")
+    r = client.get("/spec.json?v=6")
     assert r.headers["content-type"].startswith("application/json")

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -28,8 +28,8 @@ def test_manifest(monkeypatch):
     manifest = resp.json()
 
     openapi_url = manifest["api"]["url"]
-    # allow query parameters like /openapi.json?v=3
-    assert urllib.parse.urlparse(openapi_url).path.endswith("/openapi.json")
+    # allow query parameters like /spec.json?v=6
+    assert urllib.parse.urlparse(openapi_url).path.endswith("/spec.json")
     path = urllib.parse.urlparse(openapi_url).path
     spec_resp = client.get(path)
     assert spec_resp.status_code == 200


### PR DESCRIPTION
## Summary
- serve OpenAPI schema at `/spec.json`
- disable FastAPI auto-generated docs routes
- update manifest to reference `/spec.json?v=6`
- adjust tests for new OpenAPI path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686171c185108327952da19df3503674