### PR TITLE
Add OpenAPI validation step

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,3 +21,6 @@ jobs:
       - name: Run tests
         run: |
           pytest -q
+      - name: Validate OpenAPI
+        run: |
+          python scripts/check_openapi.py

--- a/scripts/check_openapi.py
+++ b/scripts/check_openapi.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""
+Compare le bloc `functions` declare dans agent.py avec celui expose
+dans static/spec.json (ou openapi.json) afin d'eviter les ecarts.
+Pour l'instant, on verifie simplement que la cle 'servers' existe.
+"""
+
+import json
+import pathlib
+import sys
+import importlib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT / "src"))
+
+from agent import functions  # s'assurer que le module existe
+
+spec_path = ROOT / "static" / "spec.json"
+if not spec_path.exists():
+    spec_path = ROOT / "openapi.json"
+
+with open(spec_path) as f:
+    spec = json.load(f)
+
+assert spec.get("servers"), "La cle 'servers' est manquante dans spec.json"
+
+print("OpenAPI spec valide \u2714")

--- a/src/agent.py
+++ b/src/agent.py
@@ -1,0 +1,2 @@
+# Placeholder module for plugin functions
+functions = []


### PR DESCRIPTION
## Summary
- add a simple OpenAPI validation script
- create an empty Python package marker
- add placeholder `agent` module
- run the validation script in CI

## Testing
- `pytest -q`
- `python scripts/check_openapi.py`


------
https://chatgpt.com/codex/tasks/task_e_68619f7312b08327961e8d7866c22984