### PR TITLE
fix(openapi): align top_tracks security with implementation

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -140,8 +140,7 @@
               "application/json": { "schema": { "type": "array", "items": {} } }
             }
           }
-        },
-        "security": []
+        }
       }
     },
 

--- a/src/tracks.py
+++ b/src/tracks.py
@@ -1,15 +1,12 @@
-from fastapi import APIRouter, HTTPException, Header
+from fastapi import APIRouter, HTTPException
 from .auth import valid_access_token
 import httpx
 
 router = APIRouter()
 
 @router.get("/top_tracks")
-async def top_tracks(authorization: str | None = Header(None)):
-    token = (
-        authorization.removeprefix("Bearer ").strip()
-        if authorization else valid_access_token()
-    )
+async def top_tracks():
+    token = valid_access_token()
     if not token:
         raise HTTPException(status_code=401, detail="Not authenticated")
     async with httpx.AsyncClient() as client:

--- a/static/ai-plugin.json
+++ b/static/ai-plugin.json
@@ -16,7 +16,7 @@
   },
   "api": {
     "type": "openapi",
-    "url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/spec.json?v=9",
+    "url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/openapi.json?v=11",
     "is_user_authenticated": true
   },
   "logo_url": "https://spotigen.vercel.app/static/logo.png",

--- a/tests/test_top_tracks.py
+++ b/tests/test_top_tracks.py
@@ -15,3 +15,33 @@ def test_top_tracks_no_token(monkeypatch):
     r = client.get("/top_tracks")
     # Missing Authorization header should return 401
     assert r.status_code == 401
+
+
+def test_top_tracks_with_token(monkeypatch):
+    monkeypatch.setenv("CLIENT_ID", "dummy")
+    monkeypatch.setenv("REDIRECT_URI", "https://example.com/callback")
+    import src.index, src.tracks, api.index
+    importlib.reload(src.index)
+    importlib.reload(src.tracks)
+
+    class DummyResp:
+        def json(self):
+            return ["ok"]
+
+    class DummyAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def get(self, *args, **kwargs):
+            return DummyResp()
+
+    monkeypatch.setattr(src.tracks, "valid_access_token", lambda: "abc")
+    monkeypatch.setattr(src.tracks.httpx, "AsyncClient", DummyAsyncClient)
+    importlib.reload(api.index)
+
+    client = TestClient(api.index.app)
+    r = client.get("/top_tracks")
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary
- update openapi spec so /top_tracks has no security block
- update Spotigen manifest to use openapi.json?v=11
- simplify /top_tracks handler to always check Redis token
- test token retrieval from Redis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ab8fe75083278ca86f418c25136f