### PR TITLE
Feature extended scopes

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -7,7 +7,7 @@
   "auth": {
     "type": "oauth",
     "client_url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/auth/login",
-    "scope": "user-top-read user-read-recently-played user-read-currently-playing user-read-playback-state playlist-modify-public playlist-modify-private",
+    "scope": "user-top-read user-read-recently-played user-read-currently-playing user-read-playback-state user-modify-playback-state playlist-modify-public playlist-modify-private",
     "authorization_url": "https://accounts.spotify.com/api/token",
     "authorization_content_type": "application/x-www-form-urlencoded",
     "verification_tokens": {

--- a/openapi.json
+++ b/openapi.json
@@ -134,8 +134,8 @@
         "summary": "Get Top Tracks",
         "operationId": "getTopTracks",
         "parameters": [
-          { "name": "limit", "in": "query", "schema": { "type": "integer", "default": 5 } },
-          { "name": "time_range", "in": "query", "schema": { "type": "string", "default": "medium_term" } }
+          { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 50, "default": 5 } },
+          { "name": "time_range", "in": "query", "schema": { "type": "string", "enum": ["short_term", "medium_term", "long_term"], "default": "medium_term" } }
         ],
         "responses": {
           "200": {
@@ -170,6 +170,42 @@
           "204": { "description": "No track playing" }
         },
         "security": []
+      }
+    },
+
+    "/play": {
+      "post": {
+        "summary": "Resume Playback",
+        "operationId": "play",
+        "responses": { "200": { "description": "Playback started" } },
+        "security": [ { "HTTPBearer": [] } ]
+      }
+    },
+
+    "/pause": {
+      "post": {
+        "summary": "Pause Playback",
+        "operationId": "pause",
+        "responses": { "200": { "description": "Playback paused" } },
+        "security": [ { "HTTPBearer": [] } ]
+      }
+    },
+
+    "/next": {
+      "post": {
+        "summary": "Skip To Next",
+        "operationId": "next",
+        "responses": { "200": { "description": "Skipped to next" } },
+        "security": [ { "HTTPBearer": [] } ]
+      }
+    },
+
+    "/previous": {
+      "post": {
+        "summary": "Skip To Previous",
+        "operationId": "previous",
+        "responses": { "200": { "description": "Went to previous" } },
+        "security": [ { "HTTPBearer": [] } ]
       }
     },
 

--- a/spec.json
+++ b/spec.json
@@ -134,8 +134,8 @@
         "summary": "Get Top Tracks",
         "operationId": "getTopTracks",
         "parameters": [
-          { "name": "limit", "in": "query", "schema": { "type": "integer", "default": 5 } },
-          { "name": "time_range", "in": "query", "schema": { "type": "string", "default": "medium_term" } }
+          { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 50, "default": 5 } },
+          { "name": "time_range", "in": "query", "schema": { "type": "string", "enum": ["short_term", "medium_term", "long_term"], "default": "medium_term" } }
         ],
         "responses": {
           "200": {
@@ -170,6 +170,42 @@
           "204": { "description": "No track playing" }
         },
         "security": []
+      }
+    },
+
+    "/play": {
+      "post": {
+        "summary": "Resume Playback",
+        "operationId": "play",
+        "responses": { "200": { "description": "Playback started" } },
+        "security": [ { "HTTPBearer": [] } ]
+      }
+    },
+
+    "/pause": {
+      "post": {
+        "summary": "Pause Playback",
+        "operationId": "pause",
+        "responses": { "200": { "description": "Playback paused" } },
+        "security": [ { "HTTPBearer": [] } ]
+      }
+    },
+
+    "/next": {
+      "post": {
+        "summary": "Skip To Next",
+        "operationId": "next",
+        "responses": { "200": { "description": "Skipped to next" } },
+        "security": [ { "HTTPBearer": [] } ]
+      }
+    },
+
+    "/previous": {
+      "post": {
+        "summary": "Skip To Previous",
+        "operationId": "previous",
+        "responses": { "200": { "description": "Went to previous" } },
+        "security": [ { "HTTPBearer": [] } ]
       }
     },
 

--- a/src/index.py
+++ b/src/index.py
@@ -112,3 +112,35 @@ async def remove_tracks_from_playlist(
 ):
     await spotify_client.remove_tracks_from_playlist(playlist_id, track_uris)
     return PlainTextResponse(status_code=200)
+
+
+@app.post("/play")
+async def resume_playback(
+    spotify_client: Annotated[SpotifyClient, Depends(get_spotify_client)],
+):
+    await spotify_client.play()
+    return PlainTextResponse(status_code=200)
+
+
+@app.post("/pause")
+async def pause_playback(
+    spotify_client: Annotated[SpotifyClient, Depends(get_spotify_client)],
+):
+    await spotify_client.pause()
+    return PlainTextResponse(status_code=200)
+
+
+@app.post("/next")
+async def next_track(
+    spotify_client: Annotated[SpotifyClient, Depends(get_spotify_client)],
+):
+    await spotify_client.next()
+    return PlainTextResponse(status_code=200)
+
+
+@app.post("/previous")
+async def previous_track(
+    spotify_client: Annotated[SpotifyClient, Depends(get_spotify_client)],
+):
+    await spotify_client.previous()
+    return PlainTextResponse(status_code=200)

--- a/src/services/spotify.py
+++ b/src/services/spotify.py
@@ -149,3 +149,39 @@ class SpotifyClient:
         if response.status_code >= 400:
             raise HTTPException(status_code=response.status_code, detail=response.text)
         return response.json()
+
+    async def play(self):
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/me/player/play",
+                headers=self._auth_headers(),
+            )
+        if response.status_code >= 400:
+            raise HTTPException(status_code=response.status_code, detail=response.text)
+
+    async def pause(self):
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/me/player/pause",
+                headers=self._auth_headers(),
+            )
+        if response.status_code >= 400:
+            raise HTTPException(status_code=response.status_code, detail=response.text)
+
+    async def next(self):
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/me/player/next",
+                headers=self._auth_headers(),
+            )
+        if response.status_code >= 400:
+            raise HTTPException(status_code=response.status_code, detail=response.text)
+
+    async def previous(self):
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/me/player/previous",
+                headers=self._auth_headers(),
+            )
+        if response.status_code >= 400:
+            raise HTTPException(status_code=response.status_code, detail=response.text)

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,10 +2,10 @@ from fastapi import Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from src.services.spotify import SpotifyClient
 
-bearer_scheme = HTTPBearer()
+bearer_scheme = HTTPBearer(auto_error=False)
 
 def ensure_token_passed(credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme)):
-    if credentials.scheme != "Bearer" or not credentials.credentials:
+    if not credentials or credentials.scheme != "Bearer" or not credentials.credentials:
         raise HTTPException(
             status_code=401, detail="Invalid or missing access token")
     return credentials.credentials

--- a/static/ai-plugin-dev.json
+++ b/static/ai-plugin-dev.json
@@ -7,7 +7,7 @@
   "auth": {
     "type": "oauth",
     "client_url": "https://accounts.spotify.com/authorize",
-    "scope": "user-top-read user-read-recently-played user-read-currently-playing user-read-playback-state playlist-modify-public playlist-modify-private",
+    "scope": "user-top-read user-read-recently-played user-read-currently-playing user-read-playback-state user-modify-playback-state playlist-modify-public playlist-modify-private",
     "authorization_url": "https://accounts.spotify.com/api/token",
     "authorization_content_type": "application/x-www-form-urlencoded",
     "verification_tokens": {

--- a/static/ai-plugin.json
+++ b/static/ai-plugin.json
@@ -7,7 +7,7 @@
   "auth": {
     "type": "oauth",
     "client_url": "https://accounts.spotify.com/authorize",
-    "scope": "user-top-read user-read-recently-played user-read-currently-playing user-read-playback-state playlist-modify-public playlist-modify-private",
+    "scope": "user-top-read user-read-recently-played user-read-currently-playing user-read-playback-state user-modify-playback-state playlist-modify-public playlist-modify-private",
     "authorization_url": "https://accounts.spotify.com/api/token",
     "authorization_content_type": "application/x-www-form-urlencoded",
     "verification_tokens": {

--- a/tests/test_playback_controls.py
+++ b/tests/test_playback_controls.py
@@ -1,0 +1,14 @@
+import os, sys, importlib
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from fastapi.testclient import TestClient
+
+
+def test_pause_requires_auth(monkeypatch):
+    monkeypatch.setenv("CLIENT_ID", "dummy")
+    monkeypatch.setenv("REDIRECT_URI", "https://example.com/callback")
+    import src.index, api.index
+    importlib.reload(src.index)
+    importlib.reload(api.index)
+    client = TestClient(api.index.app)
+    r = client.post("/pause")
+    assert r.status_code == 401

--- a/tests/test_top_tracks.py
+++ b/tests/test_top_tracks.py
@@ -46,3 +46,35 @@ def test_top_tracks_with_token(monkeypatch):
     client = TestClient(api.index.app)
     r = client.get("/top_tracks")
     assert r.status_code == 200
+
+
+def test_top_tracks_params(monkeypatch):
+    monkeypatch.setenv("CLIENT_ID", "dummy")
+    monkeypatch.setenv("REDIRECT_URI", "https://example.com/callback")
+    import src.index, src.tracks, api.index
+    importlib.reload(src.index)
+    importlib.reload(src.tracks)
+
+    class DummyResp:
+        status_code = 200
+        def json(self):
+            return list(range(50))
+
+    class DummyAsyncClient:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def get(self, *args, **kwargs):
+            assert kwargs.get("params", {}).get("limit") == 50
+            assert kwargs.get("params", {}).get("time_range") == "long_term"
+            return DummyResp()
+
+    monkeypatch.setattr(src.tracks, "valid_access_token", lambda: "abc")
+    monkeypatch.setattr(src.tracks.httpx, "AsyncClient", DummyAsyncClient)
+    importlib.reload(api.index)
+
+    client = TestClient(api.index.app)
+    r = client.get("/top_tracks?limit=50&time_range=long_term")
+    assert r.status_code == 200
+    assert len(r.json()) == 50


### PR DESCRIPTION
## Summary
- expand OAuth scopes to include playback control
- document new endpoints for playback and detailed top track parameters
- add SpotifyClient helpers for play, pause, next and previous
- expose playback routes
- return 401 on missing Authorization headers
- test playback auth requirement and top tracks parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d345ba4c8327a4d825a3d233abff