### PR TITLE
fix(playlist): resolve name→ID before fetching tracks

### DIFF
--- a/src/index.py
+++ b/src/index.py
@@ -93,7 +93,8 @@ async def get_playlist_tracks(
     playlist_id: str,
     spotify_client: Annotated[SpotifyClient, Depends(get_spotify_client)],
 ):
-    return await spotify_client.get_tracks_from_playlist(playlist_id)
+    true_id = await spotify_client._playlist_id(playlist_id)
+    return await spotify_client.get_tracks_from_playlist(true_id)
 
 
 @app.post("/playlist/{playlist_id}/tracks")

--- a/src/services/spotify.py
+++ b/src/services/spotify.py
@@ -100,6 +100,21 @@ class SpotifyClient:
             )
         return response.json()["id"]
 
+    async def _playlist_id(self, pid_or_name: str) -> str:
+        """Return a valid Spotify playlist ID.
+
+        If ``pid_or_name`` already looks like a Spotify ID (22 characters and no
+        spaces), return it unchanged. Otherwise resolve it by searching the
+        user's playlists via :meth:`find_playlist`.
+        """
+
+        if len(pid_or_name) == 22 and " " not in pid_or_name:
+            return pid_or_name
+        pl_id = await self.find_playlist(pid_or_name)
+        if pl_id is None:
+            raise HTTPException(status_code=404, detail="Playlist not found")
+        return pl_id
+
     async def get_tracks_from_playlist(self, playlist_id: str):
         async with httpx.AsyncClient() as client:
             response = await client.get(


### PR DESCRIPTION
## Summary
- add helper to resolve playlist names to IDs
- use helper so GET /playlist/{id}/tracks accepts names or IDs

## Testing
- `pytest -q` *(fails: httpx has no attribute '_client')*

------
https://chatgpt.com/codex/tasks/task_e_68629dd7e374832795f766dbb543d2aa