### PR TITLE
feat: return full playlist object + proper 404

### DIFF
--- a/src/index.py
+++ b/src/index.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
 from fastapi.staticfiles import StaticFiles
@@ -92,7 +92,7 @@ async def get_playlist(
 ):
     playlist = await spotify_client.find_playlist(name)
     if playlist is None:
-        return JSONResponse(status_code=404, content={"message": "Playlist not found"})
+        raise HTTPException(404, "Playlist not found")
     return playlist
 
 
@@ -121,7 +121,8 @@ async def add_tracks_to_playlist(
     track_titles: TrackTitles,
     spotify_client: Annotated[SpotifyClient, Depends(get_spotify_client)],
 ):
-    await spotify_client.add_tracks_to_playlist(playlist_id, track_titles)
+    true_id = await spotify_client._playlist_id(playlist_id)
+    await spotify_client.add_tracks_to_playlist(true_id, track_titles)
     return PlainTextResponse(status_code=200)
 
 
@@ -131,7 +132,8 @@ async def remove_tracks_from_playlist(
     track_uris: TrackURIs,
     spotify_client: Annotated[SpotifyClient, Depends(get_spotify_client)],
 ):
-    await spotify_client.remove_tracks_from_playlist(playlist_id, track_uris)
+    true_id = await spotify_client._playlist_id(playlist_id)
+    await spotify_client.remove_tracks_from_playlist(true_id, track_uris)
     return PlainTextResponse(status_code=200)
 
 

--- a/static/ai-plugin.json
+++ b/static/ai-plugin.json
@@ -16,7 +16,7 @@
   },
   "api": {
     "type": "openapi",
-    "url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/spec.json?v=16",
+    "url": "https://spotigen-chat-gpt-plugin-production.up.railway.app/spec.json?v=17",
     "is_user_authenticated": true
   },
   "logo_url": "https://spotigen.vercel.app/static/logo.png",

--- a/tests/test_playlist_lookup.py
+++ b/tests/test_playlist_lookup.py
@@ -1,0 +1,48 @@
+import os, sys, importlib
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from fastapi.testclient import TestClient
+
+
+def test_playlist_lookup(monkeypatch):
+    monkeypatch.setenv("CLIENT_ID", "dummy")
+    monkeypatch.setenv("REDIRECT_URI", "https://example.com/callback")
+    import api.index
+    import src.index
+    import src.services.spotify as spotify
+
+    class DummyResp:
+        def __init__(self, data, status=200):
+            self.status_code = status
+            self._data = data
+            self.text = ""
+        def json(self):
+            return self._data
+
+    class DummyAsyncClient:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def get(self, url, headers=None, params=None):
+            if url.endswith("/me"):
+                return DummyResp({"id": "me"})
+            if url.startswith("https://api.spotify.com/v1/users/me/playlists"):
+                return DummyResp({
+                    "items": [
+                        {"name": "House 2025", "id": "abcd", "owner": {"id": "me"}}
+                    ],
+                    "next": None,
+                })
+            raise AssertionError(f"unexpected {url}")
+
+    monkeypatch.setattr(spotify.httpx, "AsyncClient", DummyAsyncClient)
+    importlib.reload(src.index)
+    importlib.reload(api.index)
+    client = TestClient(api.index.app)
+
+    ok = client.get("/playlist", params={"name": "House 2025"}, headers={"Authorization": "Bearer x"})
+    assert ok.status_code == 200
+    assert "id" in ok.json()
+
+    not_found = client.get("/playlist", params={"name": "missing"}, headers={"Authorization": "Bearer x"})
+    assert not_found.status_code == 404


### PR DESCRIPTION
## Summary
- return playlist dict from `find_playlist`
- add `playlist_by_name` helper and use it in `_playlist_id`
- accept playlist names in track management routes
- handle missing playlists with HTTP 404
- bump manifest cache busting
- add integration test for `/playlist` lookup

## Testing
- `pytest -q`
- `python scripts/check_openapi.py`


------
https://chatgpt.com/codex/tasks/task_e_6863ed6b4fd08327827028495b9e4daa